### PR TITLE
Allow getManualOptions to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ expand the "Permissions" sections and click on the "Add more permissions" button
 
   Once the CORS permissions are updated, your bucket is ready for client side uploads.
 
-4. Create a server side service that will return the needed details for uploading files to S3.
+4. <a name="json-format"></a> Create a server side service that will return the needed details for uploading files to S3.
 your service shall return a json in the following format:
 
   ```json
@@ -129,7 +129,7 @@ attributes:
 * bucket - Specify the wanted bucket
 * s3-upload-options - Provide additional options:
   * getOptionsUri - The uri of the server service that is needed to sign the request (mentioned in section Setup#4) - Required if second option is empty.
-  * getManualOptions - if for some reason you need to have your own mechanism of getting a policy, you can simply assign your scope variable to this option. Note it should be resolved on the moment of directive load.
+  * getManualOptions - if for some reason you need to have your own mechanism of getting a policy, you can simply assign your scope variable to this option. The variable can either be an object (note it should be resolved on the moment of directive load) or a function taking a callback, which will be called with an object in the format described [in section Setup](#json-format).
   * folder - optional, specifies a folder inside the bucket the save the file to
   * enableValidation - optional, set to "false" in order to disable the field validation.
   * targetFilename - An optional attribute for the target filename. if provided the file will be renamed to the provided value instead of having the file original filename.

--- a/src/ng-s3upload/directives/s3-upload.js
+++ b/src/ng-s3upload/directives/s3-upload.js
@@ -58,7 +58,12 @@ angular.module('ngS3upload.directives', []).
 
               if(angular.isObject(opts.getManualOptions)) {
                 _upload(opts.getManualOptions);
-              } else {
+              } else if(angular.isFunction(opts.getManualOptions)) {
+                opts.getManualOptions(function (options) {
+                  _upload(options);
+                });
+              }
+              else {
                 S3Uploader.getUploadOptions(opts.getOptionsUri).then(function (s3Options) {
                   _upload(s3Options);
                 }, function (error) {


### PR DESCRIPTION
I would like to fetch the options on my own, but with the current implementation of `getManualOptions`, the object must be resolved before the directive is loaded. I thought that it would be good to fetch the object in the view, but doing this does not allow me to create the `getManualOptions` variable before loading the directive. Therefore, I thought it would be useful to allow `getManualOptions` to be a function, fetching the options when needed. If there is another way doing it without changing this code, I would also be happy about hearing about it.

@Serhioromano, you implemented the getManualOptions feature like it is now, how did you resolved the object before the directive beeing loaded?