### PR TITLE
Changed bucket URLs

### DIFF
--- a/src/ng-s3upload/directives/s3-upload.js
+++ b/src/ng-s3upload/directives/s3-upload.js
@@ -71,7 +71,7 @@ angular.module('ngS3upload.directives', []).
                   ngModel.$setValidity('uploading', false);
                 }
 
-                var s3Uri = 'https://' + bucket + '.s3.amazonaws.com/';
+                var s3Uri = 'https://s3.amazonaws.com/' + bucket + '/';
                 var key = opts.targetFilename ? scope.$eval(opts.targetFilename) : opts.folder + (new Date()).getTime() + '-' + S3Uploader.randomString(16) + "." + ext;
                 S3Uploader.upload(scope,
                     s3Uri,


### PR DESCRIPTION
Using the subdomain bucketname.s3.amazonaws.com causes issues with buckets containing a dot in their names. It makes browsers reject the issued SSL certificate. Therefore I propose using s3.amazonaws.com/bucketname to build all bucket URLs.

https://buck.et.s3.amazonaws.com/

https://s3.amazonaws.com/buck.et/