### PR TITLE
Correct npm package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ bower install ng-s3upload
 
 #### Npm
 ```
-npm install ng-s3upload
+npm install ngs3upload
 ```
 
 


### PR DESCRIPTION
The `npm` package name is `ngs3upload` instead of `ng-s3upload`.